### PR TITLE
Update Duo app version and build number

### DIFF
--- a/src/entrypoints/popup/popup.js
+++ b/src/entrypoints/popup/popup.js
@@ -157,9 +157,9 @@ async function activateDevice(rawCode) {
     app_id: "com.duosecurity.duomobile",
     full_disk_encryption: true,
     passcode_status: true,
-    app_version: "4.107.0", // need to update this periodically
-    // ^ latest version as of 3/12/26
-    app_build_number: "459010",
+    app_version: "4.108.0", // need to update this periodically
+    // ^ latest version as of 3/16/26
+    app_build_number: "4108020", // need to update this periodically
     version: "13",
     manufacturer: "unknown",
     language: "en",


### PR DESCRIPTION
Fix the above issue when trying to login today.
Looks like only updating the app version is not enough, we need to update the build number also
Bad Request (400): { "code": 40013, "message": "Duo Mobile 4.59.0 is not allowed by your administrator. Please update to Duo Mobile 4.85.0 or above and try again.", "stat": "FAIL" }